### PR TITLE
Fixed build for GHC 8.4.3, stack resolver switched to lts-12.9

### DIFF
--- a/adblock2privoxy/src/Utils.hs
+++ b/adblock2privoxy/src/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Utils (
 Struct2 (..),
 Struct3 (..),
@@ -57,9 +58,18 @@ getZipListM = getZipList.getZipList'
 zipListM :: [a] -> ZipListM a
 zipListM = ZipListM . ZipList
 
+#if (MIN_VERSION_base(4,11,0))
+instance Semigroup a => Semigroup (ZipListM a) where
+  x <> y = (<>) <$> x <*> y
+#endif
+
 instance Monoid a => Monoid (ZipListM a) where
   mempty = pure mempty
+#if (MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+#else
   mappend x y = mappend <$> x <*> y
+#endif
 
 class Struct2 f where
         struct2 :: a1 -> a2 -> f a1 a2

--- a/adblock2privoxy/stack.yaml
+++ b/adblock2privoxy/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-8.23
+resolver: lts-12.9
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Fixes #25 
@essandess I would also advise to use some CI to make sure that the package builds with at least the latest 3 GHC versions.
Also if you plan to maintain the package it makes sense to publish a new version on Hackage - the current one there - http://hackage.haskell.org/package/adblock2privoxy seems to be too old